### PR TITLE
Use pathlib for paths and validate APPDATA

### DIFF
--- a/dalamud_switcher/__main__.py
+++ b/dalamud_switcher/__main__.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import tkinter as tk
 
 from .ui import DalamudVersionSwitcher
@@ -8,9 +8,9 @@ def main():
     root = tk.Tk()
 
     # Set application icon if available
-    icon_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "icon_V6O_icon.ico"))
-    if os.path.exists(icon_path):
-        root.iconbitmap(icon_path)
+    icon_path = Path(__file__).resolve().parent.parent / "icon_V6O_icon.ico"
+    if icon_path.exists():
+        root.iconbitmap(str(icon_path))
 
     app = DalamudVersionSwitcher(root)
     root.mainloop()


### PR DESCRIPTION
## Summary
- switch path handling to pathlib
- validate APPDATA on Windows and fall back to Linux default path

## Testing
- `python -m compileall dalamud_switcher`


------
https://chatgpt.com/codex/tasks/task_e_68958be71ec0832db3df433ab44b8c0c