### PR TITLE
Add Linux build script and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,26 @@ On Windows, the included batch script runs the same command inside a virtual env
 ```bat
 build.bat
 ```
+
+## Linux Build & Install
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Build the executable:
+
+```bash
+./build.sh
+```
+
+Install the resulting binary by copying it into your PATH, for example:
+
+```bash
+cp dist/__main__ ~/.local/bin/dalamud_switcher
+```
+
+> **Note:** Tkinter on Linux expects a `.png` icon and the `iconphoto` method.
+> Convert `icon_V6O_icon.ico` to `.png` if you want the window to show an icon.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+pyinstaller --onefile --windowed --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py


### PR DESCRIPTION
## Summary
- Add bash `build.sh` replicating the PyInstaller command for generating a standalone executable.
- Document Linux build and installation steps, including dependency installation and optional Tkinter icon notes.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_689590518e30832dbff31961b505f46e