### PR TITLE
Add Linux build script and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,30 @@ On Windows, the included batch script runs the same command inside a virtual env
 ```bat
 build.bat
 ```
+
+## Linux Build & Install
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the build script:
+
+```bash
+./build.sh
+```
+
+3. Install the binary:
+
+Copy the executable from `dist/` to a directory on your PATH, for example:
+
+```bash
+cp dist/__main__ ~/.local/bin/dalamud-switcher
+```
+
+Ensure `~/.local/bin` is in your `PATH`.
+
+> **Note**: Tkinter on Linux expects `.png` icons set via `iconphoto`. If the `.ico` icon does not display, convert it to `.png`.
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+pyinstaller --onefile --windowed --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py


### PR DESCRIPTION
## Summary
- add `build.sh` wrapper for PyInstaller build
- document Linux build and install steps in the README

## Testing
- `pip install -r requirements.txt`
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895d68695e4832dba9d9a92f8d39738