### PR TITLE
Add build workflow for Python project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       - run: pip install -r requirements.txt
       - name: Run build script (Windows)
         if: runner.os == 'Windows'
+        shell: cmd
         run: build.bat
       - name: Run build script (Linux)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build project on Ubuntu and Windows

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68966540d8ec832db985a8381f0da693