### PR TITLE
Add build workflow for Python project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - run: pip install -r requirements.txt
+      - name: Run build script (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: build.bat
+      - name: Run build script (Linux)
+        if: runner.os != 'Windows'
+        run: ./build.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: executables-${{ matrix.os }}
+          path: dist/*

--- a/build.bat
+++ b/build.bat
@@ -20,7 +20,7 @@ pip install -r requirements.txt
 
 REM Run PyInstaller
 echo Building with PyInstaller...
-pyinstaller --onefile --windowed --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py
+pyinstaller --onefile --windowed --name "Dalamud Version Switcher" --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py
 
 REM Done
 echo Build complete!

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-pyinstaller --onefile --windowed --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py
+pyinstaller --onefile --windowed --name "Dalamud Version Switcher" --icon=icon_V6O_icon.ico --clean dalamud_switcher/__main__.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build project on Ubuntu and Windows
- ensure Windows runner invokes build script via cmd
- name PyInstaller outputs "Dalamud Version Switcher" across platforms

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68966540d8ec832db985a8381f0da693